### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+install: bundle install --jobs=3 --retry=3
 rvm:
   - 2.2.2
 script: rspec spec


### PR DESCRIPTION
change the travis config so bundle doesn't install only production dependencies, thus leaving out rspec.  - should probably have a CI group for dependencies. 